### PR TITLE
simplify `tree_rows` helper by only counting bits

### DIFF
--- a/pytreexo.py
+++ b/pytreexo.py
@@ -1,5 +1,4 @@
 import copy
-import math
 import hashlib
 
 
@@ -82,12 +81,8 @@ def parent(pos: int, total_rows: int) -> int:
     return (pos >> 1) | (1 << total_rows)
 
 
-def next_power_of_2(x: int) -> int:
-    return 1 if x == 0 else 2**(x - 1).bit_length()
-
-
 def tree_rows(n: int) -> int:
-    return int(math.log2(next_power_of_2(n)))
+    return 0 if n == 0 else (n - 1).bit_length()
 
 
 def row_maxpos(row: int, total_row: int) -> int:


### PR DESCRIPTION
This helper basically calculates the number of trailing zeros of the next power of two of the input number, which can be simply achieved by counting the number of bits after the input number is reduced by 1 (to take perfect powers of two into account). Tests still pass, additionally the following script was used to verify this for n from zero up to one billion:

```
#!/usr/bin/env python3
import math


def next_power_of_2(x: int) -> int:
    return 1 if x == 0 else 2**(x - 1).bit_length()


def tree_rows_old(n: int) -> int:
    return int(math.log2(next_power_of_2(n)))


def tree_rows_new(n: int) -> int:
    return (n - 1).bit_length()


for n in range(1, 1_000_000_000):
    assert tree_rows_old(n) == tree_rows_new(n)

```