### PR TITLE
change verify so it doesn't return indexes

### DIFF
--- a/pytreexo.py
+++ b/pytreexo.py
@@ -58,7 +58,7 @@ class Stump:
         if len(root_idxs) != len(root_candidates):
             raise("calculated roots from the proof and matched roots differ")
 
-    def delete(self, dels: [bytes], proof: Proof):
+    def delete(self, proof: Proof):
         modified_roots = calculate_roots(self.numleaves, None, proof)
         root_idxs = getrootidxs(self.numleaves, proof.targets)
         for i, idx in enumerate(root_idxs):

--- a/tests/test_stump.py
+++ b/tests/test_stump.py
@@ -57,7 +57,7 @@ class TestStump(unittest.TestCase):
 
                 proofhashes = [bytes.fromhex(proof_str) for proof_str in test['proofhashes']]
                 proof = pytreexo.Proof(test['target_values'], proofhashes)
-                s.delete(del_hashes, proof)
+                s.delete(proof)
 
                 for i, expected_str in enumerate(test['expected_roots']):
                     root = s.roots[i]


### PR DESCRIPTION
A separate function is created so that the verify function does not return indexes.